### PR TITLE
Use Krastorio 2 science packs

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -55,6 +55,7 @@ krastorio.technologies.enforceUsedSciencePacksInPrerequisites()
 -- OPTION FIXES
 ---------------------------------------------------------------------------
 -- Apply the choosen science pack recipes
+require("prototypes.vanilla-changes.optional.modify-science-packs-recipes")
 -- Final fuels fixes
 require("prototypes.vanilla-changes.optional.rebalance-vehicles&fuels-final-fixes")
 ---------------------------------------------------------------------------

--- a/prototypes/vanilla-changes/optional/modify-science-packs-recipes.lua
+++ b/prototypes/vanilla-changes/optional/modify-science-packs-recipes.lua
@@ -1,0 +1,39 @@
+-- -- -- Apply the choosen science pack recipes
+
+-- Base
+require("lib.public.data-stages.science-pack-recipe")
+-- Variations
+require("compatibility-scripts.settings-updates.science-pack-variations")
+
+-- Change Recipes
+data.raw.recipe["automation-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["automation-science-pack"]
+data.raw.recipe["logistic-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["logistic-science-pack"]
+data.raw.recipe["military-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["military-science-pack"]
+data.raw.recipe["chemical-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["chemical-science-pack"]
+data.raw.recipe["production-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["production-science-pack"]
+data.raw.recipe["utility-science-pack"] =
+  krastorio.science_pack_recipes["Krastorio 2"]["utility-science-pack"]
+
+-- Check and remove ingredients if the recipe is impossible
+local unlockable_items = krastorio.recipes.findNotUnlockableRecipes()
+
+krastorio.recipes.removeIngredients("automation-science-pack", unlockable_items)
+krastorio.recipes.removeIngredients("logistic-science-pack", unlockable_items)
+krastorio.recipes.removeIngredients("military-science-pack", unlockable_items)
+krastorio.recipes.removeIngredients("production-science-pack", unlockable_items)
+krastorio.recipes.removeIngredients("utility-science-pack", unlockable_items)
+
+-- If K2 category exist use them
+krastorio.recipes.setCategoryIfExist("production-science-pack", "t2-tech-cards")
+krastorio.recipes.setCategoryIfExist("utility-science-pack", "t2-tech-cards")
+krastorio.recipes.setCategoryIfExist(kr_optimization_tech_card_name, "t3-tech-cards")
+
+-- Remove useless prerequisite
+if not krastorio.recipes.hasIngredient("production-science-pack", "electric-furnace") then
+  krastorio.technologies.removePrerequisite("production-science-pack", "advanced-material-processing-2")
+end


### PR DESCRIPTION
Hey! I am not sure really what the intent is here and I think the science-pack-variations could probably be cleaned up. I suppose the idea is to keep only "Krastorio 2" and remove "Vanilla" maybe? I can do further cleanup if I know what direction we want to head into.

In any case, this enabled "Krastorio 2" science packs by default so that the recommended experience works! See screenshots.

Many thanks

![Screenshot From 2024-12-04 20-48-03](https://github.com/user-attachments/assets/cdfd5437-2c33-42c1-a3ec-57ef9d1e735c)
![Screenshot From 2024-12-04 20-48-08](https://github.com/user-attachments/assets/53fdfbb3-4ff4-4b1f-b217-fd01b5c4e237)
![Screenshot From 2024-12-04 20-48-12](https://github.com/user-attachments/assets/2b818879-a3e8-4199-a8e9-7a52e1ebb19d)
![Screenshot From 2024-12-04 20-48-16](https://github.com/user-attachments/assets/11f88a17-401b-49c2-9543-4873173b00bc)
![Screenshot From 2024-12-04 20-48-20](https://github.com/user-attachments/assets/a585fa45-2bed-4964-a09f-eebe35bf6fb9)
![Screenshot From 2024-12-04 20-48-25](https://github.com/user-attachments/assets/3069e889-0cf4-437c-b539-4d4ad10be308)
